### PR TITLE
Fixed a typo in AuthorizationResponse

### DIFF
--- a/src/Dto/AuthorizationResponse.php
+++ b/src/Dto/AuthorizationResponse.php
@@ -2233,7 +2233,7 @@ class AuthorizationResponse extends ApiResponse
 
         // grant
         $_grant = LanguageUtility::getFromArray('grant', $array);
-        $this->setCrant(
+        $this->setGrant(
             LanguageUtility::convertArrayToArrayCopyable(
                 $_grant, __NAMESPACE__ . '\Grant'));
 


### PR DESCRIPTION
There seems to be a typo in AuthorizationResponse file (setCrant instead of setGrant)